### PR TITLE
fix(items,jewels): match mods with decimal display values

### DIFF
--- a/src/pages/item/ItemOuput.test.ts
+++ b/src/pages/item/ItemOuput.test.ts
@@ -1,0 +1,71 @@
+import {generateRareItemRegex} from "./ItemOuput";
+import {ItemAffixRegex} from "../../generated/GeneratedItemMods";
+import {ItemCraftingSettings} from "../../utils/SavedSettings";
+
+const baseAffix: ItemAffixRegex = {
+  desc: "Regenerate # Life per second",
+  regex: "^regenerate \\d+ l",
+  start: 0,
+  end: 0,
+  disabled: [],
+  before: [],
+  on: [0],
+  after: [],
+  affixtype: "SUFFIX",
+  stats: [],
+  affixes: [],
+};
+
+const baseSettings = (overrides: {value?: string} = {}): {
+  affixMap: Record<string, ItemAffixRegex>;
+  settings: ItemCraftingSettings;
+} => ({
+  affixMap: {"helmet|life_regen": baseAffix},
+  settings: {
+    itembase: {baseType: "helmet", item: "Helmet", rarity: "Rare"},
+    selectedRareMods: {
+      "helmet|life_regen": {
+        itembase: {baseType: "helmet", item: "Helmet", rarity: "Rare"},
+        selected: true,
+        values: overrides.value !== undefined ? {0: overrides.value} : {},
+      },
+    },
+    selectedMagicMods: [],
+    rareSettings: {matchAnyMod: true, matchPrefixAndSuffix: false},
+    magicSettings: {onlyIfBothPrefixAndSuffix: false, matchOpenAffix: false},
+    customText: {value: "", enabled: false},
+  },
+});
+
+const stripQuotes = (s: string) => s.replace(/^"|"$/g, "");
+
+describe("generateRareItemRegex — decimal values (regression for #264)", () => {
+  test("matches decimal life-regen value when user specified a minimum", () => {
+    const {affixMap, settings} = baseSettings({value: "90"});
+    const out = generateRareItemRegex(affixMap, settings);
+    const re = new RegExp(stripQuotes(out), "i");
+    expect(re.test("Regenerate 127.7 Life per second")).toBe(true);
+  });
+
+  test("matches integer life-regen value when user specified a minimum", () => {
+    const {affixMap, settings} = baseSettings({value: "90"});
+    const out = generateRareItemRegex(affixMap, settings);
+    const re = new RegExp(stripQuotes(out), "i");
+    expect(re.test("Regenerate 127 Life per second")).toBe(true);
+  });
+
+  test("matches decimal value with no user-specified minimum", () => {
+    const {affixMap, settings} = baseSettings();
+    const out = generateRareItemRegex(affixMap, settings);
+    const re = new RegExp(stripQuotes(out), "i");
+    expect(re.test("Regenerate 127.7 Life per second")).toBe(true);
+  });
+
+  test("does NOT match values below the user-specified minimum", () => {
+    const {affixMap, settings} = baseSettings({value: "90"});
+    const out = generateRareItemRegex(affixMap, settings);
+    const re = new RegExp(stripQuotes(out), "i");
+    expect(re.test("Regenerate 25.5 Life per second")).toBe(false);
+    expect(re.test("Regenerate 89 Life per second")).toBe(false);
+  });
+});

--- a/src/pages/item/ItemOuput.ts
+++ b/src/pages/item/ItemOuput.ts
@@ -70,13 +70,10 @@ export function generateRareItemRegex(
       const hasRangeInsideRegex = rangeInRegex !== undefined
         && e.value.values[rangeInRegex] !== ""
         && e.value.values[rangeInRegex] !== undefined;
-      const regex = hasRangeInsideRegex
-        ? e.regex.regex
-          .replace(
-            "\\d+",
-            generateNumberRegex(e.value.values[rangeInRegex], false).replaceAll(".", "\\d")
-          )
-        : e.regex.regex;
+      const numberPattern = hasRangeInsideRegex
+        ? generateNumberRegex(e.value.values[rangeInRegex], false).replaceAll(".", "\\d")
+        : "\\d+";
+      const regex = e.regex.regex.replace("\\d+", `${numberPattern}(\\.\\d+)?`);
       const numbersBefore = e.regex.before
         .map((number) => e.value.values[number])
         .filter((e) => e !== undefined && e !== "")

--- a/src/pages/jewel/JewelOutput.test.ts
+++ b/src/pages/jewel/JewelOutput.test.ts
@@ -1,0 +1,34 @@
+import {generateJewelRegex} from "./JewelOutput";
+import {JewelSettings} from "../../utils/SavedSettings";
+
+const baseSettings = (overrides: Partial<JewelSettings> = {}): JewelSettings => ({
+  allMatch: false,
+  magicOnly: false,
+  abyssJewel: true,
+  selectedRegular: [],
+  selectedAbyss: [],
+  matchBothPrefixAndSuffix: false,
+  matchOpenPrefixSuffix: false,
+  ...overrides,
+});
+
+const stripQuotes = (s: string) => s.replace(/^"|"$/g, "");
+
+describe("generateJewelRegex — decimal values (#264 follow-up)", () => {
+  test("'Minions Regenerate % of Life per second' (abyss, decimal-display) matches in-game text", () => {
+    const out = generateJewelRegex(
+      baseSettings({selectedAbyss: ["Minions Regenerate (0.4-0.8)% of Life per second"]}),
+    );
+    const re = new RegExp(stripQuotes(out), "i");
+    expect(re.test("Minions Regenerate 0.4% of Life per second")).toBe(true);
+    expect(re.test("Minions Regenerate 0.8% of Life per second")).toBe(true);
+  });
+
+  test("Integer-display jewel mods still match (no regression)", () => {
+    const out = generateJewelRegex(
+      baseSettings({selectedAbyss: ["Minions Regenerate (42-60) Life per second"]}),
+    );
+    const re = new RegExp(stripQuotes(out), "i");
+    expect(re.test("Minions Regenerate 50 Life per second")).toBe(true);
+  });
+});

--- a/src/pages/jewel/JewelOutput.ts
+++ b/src/pages/jewel/JewelOutput.ts
@@ -60,7 +60,7 @@ function generateJewel(
   lookup: Map<string, JewelRegex>
 ): string {
   const regex = selectedMods.map((mod) => {
-    return lookup.get(mod)!!.regex;
+    return lookup.get(mod)!!.regex.replace("\\d+", "\\d+(\\.\\d+)?");
   });
   if (regex.length === 0) return "";
   return settings.allMatch


### PR DESCRIPTION
Closes #264.

## Bug

For mods whose in-game display has a decimal value (over time), the generated regex uses `\d+` which stops at the first non-digit. The trailing ` l` (or `%`) in the regex then fails to match because the next char in the item text is `.`, not a space.

Concrete example from #264:

```
Item text: Regenerate 127.7 Life per second
Generated regex: "e ([9-9]\d|\d\d\d) l"   ← \d\d\d matches "127", then needs " l" but sees ".7"
```

Result: 127.7 Life per second is never matched, regardless of the user's min value.

## Fix

After the `\d+` substitution, append `(\.\d+)?` so an optional fractional part is consumed. Same transform on the jewel side — `JewelOutput` uses the regex string verbatim from generated data, so the substitution lives there.

```
Post-fix regex: "e ([9-9]\d|\d\d\d)(\.\d+)? l"
```

The `(\.\d+)?` is optional, so integer-only mods (e.g. ``+217 to maximum Life``) are unaffected.

## Affected mods

Audited the full mod dataset (`GeneratedItemMods.ts`, `GeneratedJewel.ts`, `GeneratedTattoo.ts`, `GeneratedMagicItem.ts`, map mods) for `\d+`-pattern regexes whose affixes display decimal values:

| Page | Mod |
| --- | --- |
| Items (rare) | Regenerate # Life per second |
| Items (rare) | Regenerate #% of Life per second |
| Items (rare) | Minions Regenerate #% of Life per second |
| Jewels (abyss) | Minions Regenerate (0.4-0.8)% of Life per second |

Magic items, tattoos and maps have no decimal-display mods with a `\d+` regex.

## Test plan

- [x] `npm test` — 29 tests pass (6 new across `ItemOuput.test.ts` and `JewelOutput.test.ts`, covering: min specified / no min / values below min still excluded / integer-display mods unaffected)
- [x] End-to-end verified against real generated data + the exact item text from #264 — generated regex `"e ([9-9]\d|\d\d\d)(\.\d+)? l"` correctly matches `Regenerate 127.7 Life per second`
- [x] `tsc --noEmit` clean
- [ ] Manual in-game verification
