### PR TITLE
chore: try to improve keywords matching

### DIFF
--- a/poe/index.html
+++ b/poe/index.html
@@ -14,7 +14,7 @@
     <meta name="description"
           content="Path of Exile 1 Regex — generate vendor, map, expedition, item, flask, heist, scarab, tattoo, runegraft and jewel search strings."/>
     <meta name="keywords"
-          content="path of exile, poe, gaming, action rpg, regex, regular expression, vendor, maps, expedition, heist, scarab, tattoo, runegraft">
+          content="path of exile, poe, gaming, action rpg, search, syntax, stash, items, regex, regular expression, vendor, maps, expedition, heist, scarab, tattoo, runegraft">
     <link rel="manifest" href="/manifest.json"/>
     <title>Path of Exile Regex</title>
 </head>

--- a/poe2/index.html
+++ b/poe2/index.html
@@ -14,7 +14,7 @@
     <meta name="description"
           content="Path of Exile 2 Regex — generate vendor, item, waystone, tablet and relic search strings."/>
     <meta name="keywords"
-          content="path of exile 2, poe2, gaming, action rpg, regex, regular expression, vendor, waystone, tablet, relic">
+          content="path of exile 2, poe2, gaming, action rpg, search, syntax, stash, items, regex, regular expression, vendor, waystone, tablet, relic">
     <link rel="manifest" href="/manifest.json"/>
     <title>Path of Exile 2 Regex</title>
 </head>


### PR DESCRIPTION
Looking at conversation where poe.re or poe2.re seems to appear in discord and other places, people are most often not aware of the term "regex". Tried adding new keyword matching that might be more intuitive and for some have appeared in those discussions. 